### PR TITLE
Add href assertion to React test

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -5,4 +5,5 @@ test('renders learn react link', () => {
   render(<App />);
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();
+  expect(linkElement).toHaveAttribute('href', 'https://reactjs.org');
 });


### PR DESCRIPTION
## Summary
- enhance React App test by verifying the link's href

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6866eb33912c83308636c6bde5351a02